### PR TITLE
Fix/clean/refactor is_loop_carried function and add new is_loop_independent function.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 				"${test}"
 				"${test}"
 				"0"
+				"candl"
 			)
 			set_tests_properties("tests_unitary_${test}" PROPERTIES ENVIRONMENT "top_builddir=${CMAKE_CURRENT_BINARY_DIR}")
 		endforeach()
@@ -196,6 +197,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 				"${test}"
 				"${test}"
 				"1"
+				"candl"
 			)
 			set_tests_properties("tests_transformations_must_fail_${test}" PROPERTIES ENVIRONMENT "top_builddir=${CMAKE_CURRENT_BINARY_DIR}")
 		endforeach()
@@ -216,6 +218,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 				"${test}"
 				"${test}"
 				"1"
+				"candl"
 			)
 			set_tests_properties("tests_transformations_working_${test}" PROPERTIES ENVIRONMENT "top_builddir=${CMAKE_CURRENT_BINARY_DIR}")
 		endforeach()

--- a/include/candl/dependence.h
+++ b/include/candl/dependence.h
@@ -98,8 +98,8 @@ int                    candl_dependence_check_domain_is_included(
                                         struct osl_relation*, int);
 int                    candl_dependence_scalar_is_privatizable_at(
                                         struct osl_scop*, int, int);
-int                    candl_dependence_is_loop_carried(struct osl_scop*,
-                                        struct osl_dependence*, int);
+int                    candl_dependence_is_loop_carried(struct osl_dependence*, int);
+int                    candl_dependence_is_loop_independent(struct osl_dependence*);
 void                   candl_dependence_prune_scalar_waw(struct osl_scop*,
                                         candl_options_p,
                                         struct osl_dependence**);

--- a/include/candl/piplib-wrapper.h
+++ b/include/candl/piplib-wrapper.h
@@ -55,6 +55,7 @@ osl_relation_t* pip_matrix2relation(PipMatrix*);
 int             pip_has_rational_point(osl_relation_t*, osl_relation_t*, int);
 PipQuast*       pip_solve_osl(osl_relation_t*, osl_relation_t*,
                               int, PipOptions*);
+int quast_are_equal (PipQuast*, PipQuast*, int);
 int             piplist_are_equal(PipList*, PipList*, int);
 osl_relation_t* pip_quast_to_polyhedra(PipQuast*, int, int);
 osl_relation_t* pip_quast_no_solution_to_polyhedra(PipQuast*, int, int);

--- a/source/dependence.c
+++ b/source/dependence.c
@@ -1730,7 +1730,6 @@ int candl_dependence_is_loop_independent(osl_dependence_p dep)
  */
 int candl_dependence_is_loop_carried(osl_dependence_p dep,
                                      int loop_index) {
-  osl_relation_p msrc = NULL, mtarg = NULL;
   candl_statement_usr_p s_usr = dep->stmt_source_ptr->usr;
   candl_statement_usr_p t_usr = dep->stmt_target_ptr->usr;
   int i = 0, j = 0, k = 0;
@@ -1746,21 +1745,9 @@ int candl_dependence_is_loop_carried(osl_dependence_p dep,
   if (j != i)
     return 0;
   
-  msrc = candl_dependence_get_relation_ref_source_in_dep(dep);
-  mtarg = candl_dependence_get_relation_ref_target_in_dep(dep);
-  precision = msrc->precision;
+  precision = candl_dependence_get_relation_ref_source_in_dep(dep)->precision;
   
   
-  /* plus one for the Arr output dim */
-  int src_ref_iter = (candl_util_relation_get_line(msrc, msrc->nb_output_dims + i) != -1);
-  int dst_ref_iter = (candl_util_relation_get_line(mtarg, mtarg->nb_output_dims + i) != -1);
-
-
-  //if the src and target access relations doesn't even use the iterator of the loop index,
-  //the dependence cannot be loop carried for this loop index.
-  if (!src_ref_iter || !dst_ref_iter)
-    return 0;
-
   /* Final check. For loop i, the dependence is loop carried if there exists
      x_i^R != x_i^S in the dependence polyhedron, with
      x_{1..i-1}^R = x_{1..i-1}^S.

--- a/source/dependence.c
+++ b/source/dependence.c
@@ -1646,28 +1646,90 @@ int candl_dependence_scalar_renaming(osl_scop_p scop,
 
 
 /**
+ * @brief candl_dependence_is_loop_independent function:
+ * This function returns true if the dependence 'dep' is a loop-independent dependence.
+ *
+ * For that, it add constraints to the system dep->domain : these constrains add equality
+ * for each corresponding iterator dimensions (eg i==i', j==j', k==j' ...).
+ *
+ * @param[in] dep The osl_dependence for which this function will compute if it
+ * is loop-independent or not.
+ *
+ * @return 1 if the dependence is loop-independent, 0 if not.
+ */
+int candl_dependence_is_loop_independent(osl_dependence_p dep)
+{
+    int line = 0, col = 0, i = 0;
+    int res = 0, precision = 0;
+    int nb_constraints = 0;
+    osl_relation_p mat = NULL, test_linear_sys = NULL, empty_context = NULL;
+
+    precision = candl_dependence_get_relation_ref_source_in_dep(dep)->precision;
+
+    nb_constraints = CANDL_min(dep->source_nb_output_dims_domain, dep->target_nb_output_dims_domain);
+    mat = dep->domain;
+
+
+    //We create an empty (no row) context relation because it seems like piplib need one
+    //to know how many parameters there is.
+    empty_context = osl_relation_pmalloc(precision, 0, mat->nb_parameters + 2);
+    //We create a dependence matrix with nb_constraints more row
+    //In these row, we will place constrains on the iterator dimensions : each corresponding
+    //iterator dimensions must be equal (eg i==i', j==j'...)
+    test_linear_sys = osl_relation_pmalloc(precision,
+                           mat->nb_rows + nb_constraints,
+                           mat->nb_columns);
+    test_linear_sys->nb_output_dims = mat->nb_output_dims;
+    test_linear_sys->nb_input_dims = mat->nb_input_dims;
+    test_linear_sys->nb_local_dims = mat->nb_local_dims;
+    test_linear_sys->nb_parameters = mat->nb_parameters;
+    for (line = 0 ; line < mat->nb_rows ; line++)
+    {
+        for (col = 0 ; col < mat->nb_columns ; col++)
+        {
+            osl_int_assign(precision, &test_linear_sys->m[line][col], mat->m[line][col]);
+        }
+    }
+    for(i = 0 ; i < nb_constraints ; i++)
+    {
+        osl_int_set_si(precision, &test_linear_sys->m[mat->nb_rows + i][1 + i], 1);
+
+        osl_int_set_si(precision, 
+                &test_linear_sys->m
+                    [mat->nb_rows + i]
+                    [   
+                        1 + /* i/e column */
+                        dep->source_nb_output_dims_domain +
+                        dep->source_nb_output_dims_access +
+                        i
+                    ]
+                , -1);
+    }
+
+    res = pip_has_rational_point(test_linear_sys, empty_context, -1);
+
+    osl_relation_free(test_linear_sys);
+    return res;
+}
+
+
+/**
  * candl_dependence_is_loop_carried function:
  * This function returns true if the dependence 'dep' is loop-carried
  * for loop 'loop_index', false otherwise.
  */
-int candl_dependence_is_loop_carried(osl_scop_p scop,
-                                     osl_dependence_p dep,
+int candl_dependence_is_loop_carried(osl_dependence_p dep,
                                      int loop_index) {
   osl_relation_p msrc = NULL, mtarg = NULL;
   candl_statement_usr_p s_usr = dep->stmt_source_ptr->usr;
   candl_statement_usr_p t_usr = dep->stmt_target_ptr->usr;
-  int i, j;
-  int k, kp, l;
-  int row_k, row_kp;
-  int precision = scop->context->precision;
+  int i = 0, j = 0, k = 0;
+  int precision = 0;
   
-  /* Ensure source and sink share common loop 'loop_index', and that
-     dependence depth is consistent with the considered loop. */
+  /* Ensure source and sink share common loop 'loop_index' */
   for (i = 0; i < s_usr->depth; ++i)
     if (s_usr->index[i] == loop_index)
       break;
-  if (i != dep->depth - 1 || i >= t_usr->depth)
-    return 0;
   for (j = 0; j < t_usr->depth; ++j)
     if (t_usr->index[j] == loop_index)
       break;
@@ -1676,79 +1738,17 @@ int candl_dependence_is_loop_carried(osl_scop_p scop,
   
   msrc = candl_dependence_get_relation_ref_source_in_dep(dep);
   mtarg = candl_dependence_get_relation_ref_target_in_dep(dep);
+  precision = msrc->precision;
+  
   
   /* plus one for the Arr output dim */
-  int src_ref_iter = (candl_util_relation_get_line(msrc, i+1) != -1);
-  int dst_ref_iter = (candl_util_relation_get_line(mtarg,j+1) != -1);
+  int src_ref_iter = (candl_util_relation_get_line(msrc, msrc->nb_output_dims + i) != -1);
+  int dst_ref_iter = (candl_util_relation_get_line(mtarg, mtarg->nb_output_dims + i) != -1);
 
-  /* Ensure it is not a basic loop-independent dependence (pure
-     equality of the access functions for the surrounding iterators +
-     parameters + constant, no occurence of the inner loop iterators,
-     and contain the current loop iterator. */
-  int must_test = 0;
-  k = 1; // start after the Arr column
-  row_k = candl_util_relation_get_line(msrc, k);
-  while (!must_test &&
-         k < msrc->nb_output_dims &&
-         osl_int_zero(precision, msrc->m[row_k][0])) {
 
-    // Ensure the reference do reference the current loop iterator
-    // to be tested.
-    if (!osl_int_zero(precision, msrc->m[row_k][i])) {
-      kp = 1;
-      row_kp = candl_util_relation_get_line(mtarg, kp);
-
-      while (!must_test &&
-             kp < mtarg->nb_output_dims &&
-             osl_int_zero(precision, mtarg->m[row_kp][0])) {
-
-        if (!osl_int_zero(precision, mtarg->m[row_kp][j])) {
-          // Ensure the access functions are equal for the
-          // surrounding loop iterators, and no inner iterator
-          // is referenced.
-          if (!osl_int_eq(precision,
-                          msrc->m[row_k][0], mtarg->m[row_kp][0])) {
-            must_test = 1;
-          } else {
-            for (l = 1; l <= i; ++l)
-              if (!osl_int_eq(precision,
-                              msrc->m[row_k][msrc->nb_output_dims + l],
-                              mtarg->m[row_kp][mtarg->nb_output_dims + l])) {
-                must_test = 1;
-                break;
-              }
-          }
-          int m = l;
-          if (!must_test)
-            for (; l <= s_usr->depth+1; ++l)
-              if (!osl_int_zero(precision, msrc->m[row_k][msrc->nb_output_dims + l])) {
-                must_test = 1;
-                break;
-              }
-          if (!must_test)
-            for (; m <= t_usr->depth+1; ++m)
-              if (!osl_int_zero(precision, mtarg->m[row_kp][mtarg->nb_output_dims + m])) {
-                must_test = 1;
-                break;
-              }
-          if (!must_test)
-            for (; l < msrc->nb_columns-1; ++l, ++m)
-            if (!osl_int_eq(precision,
-                            msrc->m[row_k][msrc->nb_output_dims + l],
-                            mtarg->m[row_kp][mtarg->nb_output_dims + m])) {
-                must_test = 1;
-                break;
-              }
-        }
-        ++kp;
-        row_kp = candl_util_relation_get_line(mtarg, kp);
-      }
-    }
-    ++k;
-    row_k = candl_util_relation_get_line(msrc, k);
-  }
-  
-  if (src_ref_iter && dst_ref_iter && !must_test)
+  //if the src and target access relations doesn't even use the iterator of the loop index,
+  //the dependence cannot be loop carried for this loop index.
+  if (!src_ref_iter || !dst_ref_iter)
     return 0;
 
   /* Final check. For loop i, the dependence is loop carried if there exists
@@ -1759,16 +1759,20 @@ int candl_dependence_is_loop_carried(osl_scop_p scop,
   osl_relation_p mat = dep->domain;
   
   osl_relation_p testsyst = osl_relation_pmalloc(precision,
-                           mat->nb_rows + 1 + s_usr->depth,
+                           mat->nb_rows + s_usr->depth,
                            mat->nb_columns);
+  testsyst->nb_output_dims = mat->nb_output_dims;
+  testsyst->nb_input_dims = mat->nb_input_dims;
+  testsyst->nb_local_dims = mat->nb_local_dims;
+  testsyst->nb_parameters = mat->nb_parameters;
   for (pos = 0; pos < mat->nb_rows; ++pos)
-    for (j = 0; j < mat->nb_columns; ++j)
+    for (k = 0; k < mat->nb_columns; ++k)
       osl_int_assign(precision,
-                     &testsyst->m[pos][j], mat->m[pos][j]);
-  for (j = 0; j < i; ++j) {
-    osl_int_set_si(precision, &testsyst->m[pos+j+1][0], 0);
-    osl_int_set_si(precision, &testsyst->m[pos+j+1][1+j], -1);
-    osl_int_set_si(precision, &testsyst->m[pos+j+1][1+j+mat->nb_output_dims], 1);
+                     &testsyst->m[pos][k], mat->m[pos][k]);
+  for (k = 0; k < i; ++k) {
+    osl_int_set_si(precision, &testsyst->m[pos+k+1][0], 0);
+    osl_int_set_si(precision, &testsyst->m[pos+k+1][1+k], -1);
+    osl_int_set_si(precision, &testsyst->m[pos+k+1][1+k+mat->nb_output_dims], 1);
   }
 
   int has_pt = 0;
@@ -1777,7 +1781,7 @@ int candl_dependence_is_loop_carried(osl_scop_p scop,
   osl_int_set_si(precision, &testsyst->m[pos][testsyst->nb_columns-1], -1);
   osl_int_set_si(precision, &testsyst->m[pos][1+i], 1);
   osl_int_set_si(precision, &testsyst->m[pos][1+i+mat->nb_output_dims], -1);
-  
+
   has_pt = pip_has_rational_point(testsyst, NULL, 1);
   if (!has_pt) {
     // Test for '<'.
@@ -1884,7 +1888,7 @@ void candl_dependence_prune_with_privatization(osl_scop_p scop,
     loop_pos_priv = i;
     
     /* Check if the dependence is loop-carried at loop i. */
-    if (is_priv && candl_dependence_is_loop_carried(scop, tmp, loop_idx)) {
+    if (is_priv && candl_dependence_is_loop_carried(tmp, loop_idx)) {
       /* If so, make the dependence loop-independent. */
       row = tmp->domain->nb_rows;
       osl_relation_insert_blank_row(tmp->domain, row);

--- a/source/pruning.c
+++ b/source/pruning.c
@@ -159,31 +159,6 @@ osl_dependence_p** find_dep_paths(osl_dependence_p* ardeps,
 
 
 /**
- * Return true if the 'size' first variables in a quast are strictly
- * equal.
- */
-static
-int quast_are_equal (PipQuast* q1, PipQuast* q2, int size) {
-  if (q1 == NULL && q2 == NULL)
-    return 1;
-  if (q1 == NULL || q2 == NULL)
-    return 0;
-
-  // Inspect conditions.
-  if (q1->condition != NULL && q2->condition != NULL) {
-    PipList c1; c1.next = NULL; c1.vector = q1->condition;
-    PipList c2; c2.next = NULL; c2.vector = q2->condition;
-    if (! piplist_are_equal(&c1, &c2, size))
-      return 0;
-    return quast_are_equal(q1->next_then, q2->next_then, size) &&
-        quast_are_equal(q1->next_else, q2->next_else, size);
-  }
-  if (q1->condition != NULL || q2->condition != NULL)
-    return 0;
-  return piplist_are_equal(q1->list, q2->list, size);
-}
-
-/**
  * Return true if 'dep' is fully covered by the transitive dependences
  * in 'path'. This is a conservative functions (works only on
  * unimodular access functions + iteration domains for the sub-matrix

--- a/source/util.c
+++ b/source/util.c
@@ -63,7 +63,7 @@
  * \return                  Return the real line
  */
 int candl_util_relation_get_line(osl_relation_p relation, int column) {
-  if ((column < 0) || (column >= (relation->nb_columns-1))
+  if ((column < 0) || (column >= (relation->nb_columns-1)))
     return -1;
   int i;
   int precision = relation->precision;

--- a/source/util.c
+++ b/source/util.c
@@ -55,14 +55,15 @@
  * It returns the first line where the value is
  * different from zero in the `column'. `column' is between 0 and 
  * nb_columns-1
- * Because the lines in the scattering or access matrix may have not ordered, we have to
- * search the corresponding line, so you can use this function for that.
+ * Because the lines in the scattering or access matrix may have not
+ * been ordered, we have to search the corresponding line, so you
+ * can use this function for that.
  * \param[in] relation
  * \param[in] column        Line to search
  * \return                  Return the real line
  */
 int candl_util_relation_get_line(osl_relation_p relation, int column) {
-  if (column < 0 || column > relation->nb_columns)
+  if ((column < 0) || (column >= (relation->nb_columns-1))
     return -1;
   int i;
   int precision = relation->precision;

--- a/source/util.c
+++ b/source/util.c
@@ -52,16 +52,17 @@
 
 /**
  * candl_util_relation_get_line function:
- * Because the lines in the scattering matrix may have not ordered, we have to
- * search the corresponding line. It returns the first line where the value is
+ * It returns the first line where the value is
  * different from zero in the `column'. `column' is between 0 and 
- * nb_output_dims-1
+ * nb_columns-1
+ * Because the lines in the scattering or access matrix may have not ordered, we have to
+ * search the corresponding line, so you can use this function for that.
  * \param[in] relation
  * \param[in] column        Line to search
  * \return                  Return the real line
  */
 int candl_util_relation_get_line(osl_relation_p relation, int column) {
-  if (column < 0 || column > relation->nb_output_dims)
+  if (column < 0 || column > relation->nb_columns)
     return -1;
   int i;
   int precision = relation->precision;


### PR DESCRIPTION
Move around some code, remove now unnecessary piece of code (like useless precondition).
Fix and clean candl_dependence_is_loop_carried (the code checking if the dependence was loop-independent wasn't working).
Add a function called candl_dependence_is_loop_independent that check if a dependence is loop-independent using piplib.