### PR TITLE
Set correct OSL_CPPFLAGS when configuring with bundled version of osl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ AC_SUBST(OSL_LDFLAGS)
 AC_SUBST(OSL_LIBS)
 case "$with_osl" in
 bundled)
-  OSL_CPPFLAGS="-Isrcdir/osl/include -Iosl/include"
+  OSL_CPPFLAGS="-I$srcdir/osl/include -Iosl/include"
   OSL_LIBS="osl/libosl.la"
   ;;
 build)


### PR DESCRIPTION
When configuring candl with the bundled version of osl, OSL_CPPFLAGS
includes the incorrect path srcdir/osl/include instead of
$srcdir/osl/include (dollar sign missing), causing VPATH builds to
fail.

Steps to reproduce:

  $ git clone https://github.com/periscop/candl
  $ cd candl
  $ ./get_submodules.sh
  $ ./autogen.sh

  $ cd ..
  $ mkdir candl-build
  $ cd candl-build
  $ ../candl/configure --with-piplib=bundled --with-scoplib=bundled

  In file included from ../candl/source/candl.c:38:
  osl/include/osl/scop.h:76:11: fatal error: osl/relation.h: No such file or directory
   \# include <osl/relation.h>
           ^~~~~~~~~~~~~~~~
  compilation terminated.

This patch adds the missing dollar sign in front of srcdir and
re-enables VPATH builds.